### PR TITLE
Remove `@electron/remote` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
     "yarn-deduplicate": "^3.1.0"
   },
   "dependencies": {
-    "@electron/remote": "^1.2.1",
     "@material-ui/core": "^4.12.3",
     "@types/react-avatar-editor": "^10.3.6",
     "@types/uuid": "^8.3.1",

--- a/src/components/ImageEditor/PresetImagesModal.tsx
+++ b/src/components/ImageEditor/PresetImagesModal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { app } from '@electron/remote';
+import { ipcRenderer } from 'electron';
 import classNames from 'classnames';
 import Dialog from '@material-ui/core/Dialog';
-import { isProduction } from 'utils/env';
 import { Tooltip } from '@material-ui/core';
 
 interface Props {
@@ -74,7 +73,7 @@ export default (props: Props) => {
   );
 };
 
-const basePath = isProduction ? process.resourcesPath : `file://${app.getAppPath()}`;
+const basePath = ipcRenderer.sendSync('base-path');
 const IMAGES = Array(54)
   .fill(0)
   .map((_, i) => `${basePath}/assets/avatar/${i + 1}.png`);

--- a/src/components/JoinGroupModal.tsx
+++ b/src/components/JoinGroupModal.tsx
@@ -5,8 +5,7 @@ import Dialog from 'components/Dialog';
 import Tooltip from '@material-ui/core/Tooltip';
 import Button from 'components/Button';
 import { MdDone } from 'react-icons/md';
-import { shell } from 'electron';
-import { dialog, getCurrentWindow } from '@electron/remote';
+import { shell, ipcRenderer } from 'electron';
 import fs from 'fs-extra';
 import sleep from 'utils/sleep';
 import { useStore } from 'store';
@@ -132,7 +131,7 @@ const MyNodeInfo = observer((props: IProps) => {
               onClick={async () => {
                 state.loadingSeed = true;
                 try {
-                  const file = await dialog.showOpenDialog(getCurrentWindow(), {
+                  const file = await ipcRenderer.invoke('open-dialog', {
                     filters: [{ name: 'json', extensions: ['json'] }],
                     properties: ['openFile'],
                   });

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react-lite';
 import Dialog from 'components/Dialog';
 import Button from 'components/Button';
-import { dialog } from '@electron/remote';
+import { ipcRenderer } from 'electron';
 import fs from 'fs-extra';
 import sleep from 'utils/sleep';
 import { useStore } from 'store';
@@ -45,7 +45,7 @@ const Share = observer((props: IProps) => {
                 return;
               }
               try {
-                const file = await dialog.showSaveDialog({
+                const file = await ipcRenderer.invoke('save-dialog', {
                   defaultPath: `seed.${activeGroup.group_name}.json`,
                 });
                 if (!file.canceled && file.filePath) {

--- a/src/hooks/useAppBadgeCount.tsx
+++ b/src/hooks/useAppBadgeCount.tsx
@@ -1,6 +1,6 @@
 import { useStore } from 'store';
 import { sum } from 'lodash';
-import { app } from '@electron/remote';
+import { ipcRenderer } from 'electron';
 
 export default () => {
   const { groupStore, latestStatusStore } = useStore();
@@ -13,5 +13,5 @@ export default () => {
       },
     ),
   );
-  app.setBadgeCount(badgeCount);
+  ipcRenderer.send('set-badge-count', badgeCount);
 };

--- a/src/hooks/useSetupQuitHook.tsx
+++ b/src/hooks/useSetupQuitHook.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useStore } from 'store';
 import { ipcRenderer } from 'electron';
-import { dialog } from '@electron/remote';
 import sleep from 'utils/sleep';
 import useExitNode from 'hooks/useExitNode';
 import useActiveGroup from 'store/selectors/useActiveGroup';
@@ -23,7 +22,7 @@ export default () => {
         const ownerGroupCount = groupStore.groups.filter(
           (group) => group.owner_pubkey === activeGroup.user_pubkey,
         ).length;
-        const res = await dialog.showMessageBox({
+        const res = await ipcRenderer.invoke('message-box', {
           type: 'question',
           buttons: ['确定', '取消'],
           title: '退出节点',

--- a/src/layouts/Sidebar/MyNodeInfoModal.tsx
+++ b/src/layouts/Sidebar/MyNodeInfoModal.tsx
@@ -5,7 +5,6 @@ import Dialog from 'components/Dialog';
 import Button from 'components/Button';
 import { useStore } from 'store';
 import copy from 'copy-to-clipboard';
-import { app } from '@electron/remote';
 import MiddleTruncate from 'components/MiddleTruncate';
 import NetworkInfoModal from './NetworkInfoModal';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -134,7 +133,7 @@ const MyNodeInfo = observer(() => {
               interactive
               arrow
             >
-              <div>版本 {app.getVersion()}</div>
+              <div>版本 {ipcRenderer.sendSync('app-version')}</div>
             </Tooltip>
             <div className="px-4">|</div>
             <div

--- a/src/layouts/Sidebar/index.tsx
+++ b/src/layouts/Sidebar/index.tsx
@@ -11,8 +11,7 @@ import JoinGroupModal from 'components/JoinGroupModal';
 import MyNodeInfoModal from './MyNodeInfoModal';
 import GroupMenu from 'components/GroupMenu';
 import { useStore } from 'store';
-import { app } from '@electron/remote';
-import { isProduction } from 'utils/env';
+import { ipcRenderer } from 'electron';
 import { sum } from 'lodash';
 import Fade from '@material-ui/core/Fade';
 import getSortedGroups from 'store/selectors/getSortedGroups';
@@ -66,15 +65,12 @@ export default observer(() => {
       <div className="pl-4 pr-3 leading-none h-13 flex items-center justify-between text-gray-500 border-b border-gray-200 font-bold">
         <Tooltip
           placement="right"
-          title={`版本：${app.getVersion()}`}
+          title={`版本：${ipcRenderer.sendSync('app-version')}`}
           arrow
         >
           <div className="flex items-center">
             <img
-              src={`${isProduction
-                ? process.resourcesPath
-                : `file://${app.getAppPath()}`
-              }/assets/logo.png`}
+              src={`${ipcRenderer.sendSync('base-path')}/assets/logo.png`}
               alt="logo"
               width="24"
             />

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
 require('./main/processLock');
 require('./main/log');
-require('@electron/remote/main').initialize();
 const { app, BrowserWindow, ipcMain, Menu, Tray, dialog } = require('electron');
 const ElectronStore = require('electron-store');
 const { initQuorum, state: quorumState } = require('./main/quorum');
@@ -121,6 +120,41 @@ const main = () => {
 
   ipcMain.on('disable-app-quit-prompt', () => {
     app.quitPrompt = false;
+  });
+
+
+  ipcMain.on('app-version', (event) => {
+    const version = app.getVersion();
+    event.returnValue = version;
+  });
+
+  ipcMain.on('base-path', (event) => {
+    const basePath = isProduction ? process.resourcesPath : `file://${app.getAppPath()}`;
+    event.returnValue = basePath;
+  });
+
+  ipcMain.on('app-path', (event, arg) => {
+    const appPath = app.getPath(arg);
+    event.returnValue = appPath;
+  });
+
+  ipcMain.on('set-badge-count', (event, badgeCount) => {
+    app.setBadgeCount(badgeCount);
+  });
+
+  ipcMain.handle('open-dialog', async (event, arg) => {
+    const file = await dialog.showOpenDialog(win, arg);
+    return file;
+  });
+
+  ipcMain.handle('save-dialog', async (event, arg) => {
+    const file = await dialog.showSaveDialog(arg);
+    return file;
+  });
+
+  ipcMain.handle('message-box', async (event, arg) => {
+    const file = await dialog.showMessageBox(arg);
+    return file;
   });
 
   app.on('render-process-gone', () => {

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,6 @@
   "author": "rumsystem.net",
   "license": "MIT",
   "dependencies": {
-    "@electron/remote": "^1.2.1",
     "electron-log": "^4.3.1",
     "electron-store": "^8.0.0",
     "electron-updater": "^4.3.5",

--- a/src/standaloneModals/useMixinPayment/index.tsx
+++ b/src/standaloneModals/useMixinPayment/index.tsx
@@ -7,17 +7,17 @@ import Loading from 'components/Loading';
 import { TextField, Tooltip } from '@material-ui/core';
 import { MdInfo } from 'react-icons/md';
 import Button from 'components/Button';
-import { isWindow, isProduction } from 'utils/env';
+import { isWindow } from 'utils/env';
 import { StoreProvider, useStore } from 'store';
 import { getPaymentStatus } from 'apis/mixin';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import { app } from '@electron/remote';
+import { ipcRenderer } from 'electron';
 import { checkAmount, CURRENCIES, getMixinPaymentUrl } from './utils';
 import { v1 as uuidV1 } from 'uuid';
 import { ThemeRoot } from 'utils/theme';
 import { BsQuestionCircleFill } from 'react-icons/bs';
 
-const BASE_PASH = isProduction ? process.resourcesPath : `file://${app.getAppPath()}`;
+const BASE_PASH = ipcRenderer.sendSync('base-path');
 const getCurrencyIcon = (currency: string) => `${BASE_PASH}/assets/currency_icons/${currency}.png`;
 
 export default async (props: { name: string, mixinUID: string }) => new Promise<void>((rs) => {

--- a/src/store/selectors/getProfile.ts
+++ b/src/store/selectors/getProfile.ts
@@ -1,6 +1,5 @@
 import type { IProfile } from 'store/group';
-import { app } from '@electron/remote';
-import { isProduction } from 'utils/env';
+import { ipcRenderer } from 'electron';
 import Base64 from 'utils/base64';
 import type { IDbPersonItem } from 'hooks/useDatabase/models/person';
 
@@ -33,9 +32,7 @@ const calcAvatarIndex = (message: string) => {
 export const AVATAR_PLACEHOLDER = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';
 
 const getAvatarPath = (index: number) => {
-  const basePath = isProduction
-    ? process.resourcesPath
-    : `file://${app.getAppPath()}`;
+  const basePath = ipcRenderer.sendSync('base-path');
   return index ? `${basePath}/assets/avatar/${index}.png` : AVATAR_PLACEHOLDER;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,11 +1168,6 @@
     global-agent "^2.0.2"
     global-tunnel-ng "^2.7.1"
 
-"@electron/remote@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.nlark.com/@electron/remote/download/@electron/remote-1.2.1.tgz#665b9fc2c6a60f9e5039bf235e2c60ccd0242c32"
-  integrity sha1-ZlufwsamD55QOb8jXixgzNAkLDI=
-
 "@electron/universal@1.0.5":
   version "1.0.5"
   resolved "https://registry.nlark.com/@electron/universal/download/@electron/universal-1.0.5.tgz#b812340e4ef21da2b3ee77b2b4d35c9b86defe37"


### PR DESCRIPTION
Follow [@electron/remote](https://github.com/electron/remote/blob/main/README.md)'s advice:

> ⚠️ **Warning!** This module has [many subtle pitfalls](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31). There is almost always a better way to accomplish your task than using this module. For example, [`ipcRenderer.invoke`](https://www.electronjs.org/docs/api/ipc-renderer#ipcrendererinvokechannel-args) can serve many common use cases.

All modifications were tested on macOS 12.0.1.